### PR TITLE
Avoid possible infinite loop due to chunk ordering

### DIFF
--- a/src/audio/wav_io.c
+++ b/src/audio/wav_io.c
@@ -106,6 +106,7 @@ bool wav_io_load(const char* filename, AudioBuffer** result) {
   while (memcmp(found_chunk_id, "data", 4) != 0) {
     const uint32_t chunk_size = fread_uint32(file);
     fread_and_discard(chunk_size, file);
+    fread(found_chunk_id, 4, 1, file);
   }
 
   const uint32_t chunk_size = fread_uint32(file);


### PR DESCRIPTION
Properly re-read the chunk ID when iterating through subsequent
chunks. This avoids an infinite loop in the case where the `data`
chunk doesn't immediately follow the `fmt ` chunk.