### PR TITLE
`fread_and_discard` vs `fseek`

### DIFF
--- a/src/audio/wav_io.c
+++ b/src/audio/wav_io.c
@@ -68,7 +68,7 @@ bool wav_io_load(const char* filename, AudioBuffer** result) {
   fread(found_chunk_id, 4, 1, file);
   while (memcmp(found_chunk_id, "fmt ", 4) != 0) {
     const uint32_t chunk_size = fread_uint32(file);
-    fread_and_discard(chunk_size, file);
+    fseek(file, chunk_size, SEEK_CUR);
     fread(found_chunk_id, 4, 1, file);
   }
   const uint32_t format_chunk_size = fread_uint32(file);
@@ -97,13 +97,13 @@ bool wav_io_load(const char* filename, AudioBuffer** result) {
     return false;
   }
   if (format_chunk_size == 18) {
-    fread_and_discard(2, file);
+    fseek(file, 2, SEEK_CUR);
   }
 
   fread(found_chunk_id, 4, 1, file);
   while (memcmp(found_chunk_id, "data", 4) != 0) {
     const uint32_t chunk_size = fread_uint32(file);
-    fread_and_discard(chunk_size, file);
+    fseek(file, chunk_size, SEEK_CUR);
   }
 
   const uint32_t chunk_size = fread_uint32(file);

--- a/src/audio/wav_io.c
+++ b/src/audio/wav_io.c
@@ -18,9 +18,7 @@ static bool expect_data(const char* expected, int expected_size,
 }
 
 static void fread_and_discard(int size, FILE* file) {
-  uint8_t* data = calloc(1, size);
-  fread(data, size, 1, file);
-  free(data);
+  fseek(file, size, SEEK_CUR);
 }
 
 static uint16_t fread_uint16(FILE* file) {

--- a/src/audio/wav_io.c
+++ b/src/audio/wav_io.c
@@ -17,10 +17,6 @@ static bool expect_data(const char* expected, int expected_size,
   return result;
 }
 
-static void fread_and_discard(int size, FILE* file) {
-  fseek(file, size, SEEK_CUR);
-}
-
 static uint16_t fread_uint16(FILE* file) {
   uint16_t result;
   fread(&result, 2, 1, file);

--- a/src/audio/wav_io_test.c
+++ b/src/audio/wav_io_test.c
@@ -19,20 +19,6 @@ void test_expect_data() {
   fclose(file);
 }
 
-void test_fread_and_discard() {
-  const char* test_filename = "/tmp/test_fread_and_discard";
-  file_write(test_filename, "FooBarBaz", 9);
-
-  FILE* file = fopen(test_filename, "rb");
-  TEST_CHECK(file != NULL);
-
-  TEST_CHECK(expect_data("Foo", 3, file));
-  fread_and_discard(3, file);
-  TEST_CHECK(expect_data("Baz", 3, file));
-
-  fclose(file);
-}
-
 void test_fread_uint16() {
   const char* test_filename = "/tmp/test_fread_uint16";
   uint16_t value = 0x3123;
@@ -207,7 +193,6 @@ void test_wav_io_save_listenable() {
 
 TEST_LIST = {
   {"expect_data", test_expect_data},
-  {"fread_and_discard", test_fread_and_discard},
   {"fread_uint16", test_fread_uint16},
   {"fwrite_uint16", test_fwrite_uint16},
   {"fread_uint32", test_fread_uint32},


### PR DESCRIPTION
It looks like `fread_and_discard` acts the same as [`fseek`](https://man7.org/linux/man-pages/man3/fseek.3.html). If so, this will replace calls to `fread_and_discard` with equivalent calls to `fseek` ✌️