### PR TITLE
Use feature test to expose `setenv`

### DIFF
--- a/src/settings_test.c
+++ b/src/settings_test.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200112L
+
 #include "settings.h"
 
 #include "acutest.h"
@@ -5,9 +7,6 @@
 #include "settings.c"
 
 #include <stdlib.h>
-
-// Not sure why this declaration isn't pulled in?
-extern int setenv(const char*, const char*, int);
 
 static void create_mock_languages_dir(const char* root, const char** dirs,
   int dirs_length) {


### PR DESCRIPTION
As per the [man page](https://man7.org/linux/man-pages/man3/setenv.3.html),
`setenv` requires `_POSIX_C_SOURCE` >= 200112L to be defined
before including the appropriate header file (`stdlib.h`). As the
other included header files include some standard headers
transitively, this needs to go above all includes.